### PR TITLE
Alan/ctx canceled

### DIFF
--- a/x/batcher/batcher.go
+++ b/x/batcher/batcher.go
@@ -108,7 +108,8 @@ func (d *Destination[T]) Send(ctx context.Context, ack func(), msgs ...kawa.Mess
 		select {
 		case d.messages <- msgAck[T]{msg: m, ack: callMe}:
 		case <-ctx.Done():
-			return ctx.Err()
+			// TODO: one more flush?
+			return nil
 		}
 	}
 
@@ -157,7 +158,7 @@ loop:
 		case err = <-d.flusherr:
 			break loop
 		case <-ctx.Done():
-			// should we attempt one final flush?
+			// TODO: one more flush?
 			break loop
 		}
 	}
@@ -187,6 +188,7 @@ func (d *Destination[T]) flush(ctx context.Context) error {
 	case err := <-d.flusherr:
 		return err
 	case <-ctx.Done():
+		// TODO: one more flush?
 		return nil
 	}
 	return nil

--- a/x/batcher/batcher.go
+++ b/x/batcher/batcher.go
@@ -109,7 +109,7 @@ func (d *Destination[T]) Send(ctx context.Context, ack func(), msgs ...kawa.Mess
 		case d.messages <- msgAck[T]{msg: m, ack: callMe}:
 		case <-ctx.Done():
 			// TODO: one more flush?
-			return nil
+			return ctx.Err()
 		}
 	}
 
@@ -158,7 +158,7 @@ loop:
 		case err = <-d.flusherr:
 			break loop
 		case <-ctx.Done():
-			// TODO: one more flush?
+			err = ctx.Err()
 			break loop
 		}
 	}
@@ -189,7 +189,7 @@ func (d *Destination[T]) flush(ctx context.Context) error {
 		return err
 	case <-ctx.Done():
 		// TODO: one more flush?
-		return nil
+		return ctx.Err()
 	}
 	return nil
 }

--- a/x/batcher/batcher_test.go
+++ b/x/batcher/batcher_test.go
@@ -158,7 +158,7 @@ func TestBatcherErrors(t *testing.T) {
 
 		cancel()
 		err := <-errc
-		assert.NoError(t, err, "should not error on context canceled")
+		assert.ErrorIs(t, err, context.Canceled, "should return context canceled")
 	})
 
 	t.Run("cancellation works in deadlock", func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestBatcherErrors(t *testing.T) {
 
 		cancel()
 		err = <-errc
-		assert.NoError(t, err, "when context is canceled, it should not error")
+		assert.ErrorIs(t, err, context.Canceled, "should return context canceled")
 	})
 
 	t.Run("dont deadlock on errors returned from flush", func(t *testing.T) {

--- a/x/batcher/batcher_test.go
+++ b/x/batcher/batcher_test.go
@@ -165,7 +165,7 @@ func TestBatcherErrors(t *testing.T) {
 
 		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
 			<-c.Done()
-			return c.Err()
+			return nil
 		}
 		bat := NewDestination[string](FlushFunc[string](ff), FlushLength(1))
 
@@ -192,7 +192,7 @@ func TestBatcherErrors(t *testing.T) {
 
 		cancel()
 		err = <-errc
-		assert.EqualError(t, err, "context canceled")
+		assert.NoError(t, err, "when context is canceled, it should not error")
 	})
 
 	t.Run("dont deadlock on errors returned from flush", func(t *testing.T) {


### PR DESCRIPTION
The last PR I added changed one instance of returning `ctx.Err()` to nil, but I think it's actually better to keep it.  `context.Canceled` is an easy error to catch and ignore up the stack, but would be difficult to debug if nil is being returned unexpectedly.