### PR TITLE
batcher: major error handling overhaul

### DIFF
--- a/x/batcher/batcher_test.go
+++ b/x/batcher/batcher_test.go
@@ -43,7 +43,7 @@ func TestBatcher(t *testing.T) {
 		return nil
 	}
 
-	bat := NewDestination[string](FlushFunc[string](ff), FlushLength(1))
+	bat := NewDestination[string](FlushFunc[string](ff), Raise[string](), FlushLength(1))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 
@@ -88,6 +88,7 @@ func TestBatchFlushTimeout(t *testing.T) {
 
 	bat := NewDestination[string](
 		FlushFunc[string](ff),
+		Raise[string](),
 		FlushFrequency(1*time.Millisecond),
 		FlushLength(2),
 		StopTimeout(10*time.Millisecond),
@@ -127,7 +128,7 @@ func TestBatcherErrors(t *testing.T) {
 	}
 
 	t.Run("flush errors return from run", func(t *testing.T) {
-		bat := NewDestination[string](FlushFunc[string](ff), FlushLength(1))
+		bat := NewDestination[string](FlushFunc[string](ff), Raise[string](), FlushLength(1))
 		errc := make(chan error)
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 
@@ -155,7 +156,7 @@ func TestBatcherErrors(t *testing.T) {
 		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
 			return nil
 		}
-		bat := NewDestination[string](FlushFunc[string](ff), FlushLength(1))
+		bat := NewDestination[string](FlushFunc[string](ff), Raise[string](), FlushLength(1))
 		errc := make(chan error)
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		go func(c context.Context, ec chan error) {
@@ -173,7 +174,7 @@ func TestBatcherErrors(t *testing.T) {
 			<-c.Done()
 			return nil
 		}
-		bat := NewDestination[string](FlushFunc[string](ff), FlushLength(1), StopTimeout(10*time.Millisecond))
+		bat := NewDestination[string](FlushFunc[string](ff), Raise[string](), FlushLength(1), StopTimeout(10*time.Millisecond))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 
@@ -201,20 +202,24 @@ func TestBatcherErrors(t *testing.T) {
 		assert.ErrorIs(t, err, errDeadlock, "should return deadlock error")
 	})
 
-	t.Run("dont deadlock on errors returned from flush", func(t *testing.T) {
+	t.Run("handle errors when errors returned from flush", func(t *testing.T) {
 
 		// This test deadlocks in failure
 		// Should figure out how to write it better
 
 		flushErr := errors.New("flush error")
 		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(110 * time.Millisecond)
 			return flushErr
 		}
-		bat := NewDestination[string](FlushFunc[string](ff), FlushLength(2), FlushParallelism(2))
+		var errHandler = ErrorHandle[string](func(c context.Context, err error, msgs []kawa.Message[string]) error {
+			assert.ErrorIs(t, err, flushErr)
+			return err
+		})
+		bat := NewDestination[string](FlushFunc[string](ff), errHandler, FlushLength(2), FlushParallelism(2), StopTimeout(90*time.Millisecond))
 		errc := make(chan error)
 
-		ctx := context.Background()
+		ctx, cncl := context.WithCancel(context.Background())
 
 		go func(c context.Context, ec chan error) {
 			ec <- bat.Run(c)
@@ -231,10 +236,60 @@ func TestBatcherErrors(t *testing.T) {
 
 		done := make(chan struct{})
 		err := bat.Send(ctx, func() { close(done) }, writeMsgs...)
-		assert.NoError(t, err)
+		assert.NoError(t, err, "errors aren't returned from Send")
 
+		cncl()
+
+		// parallelism is 2, so max processing time is 220ms (110ms for the first
+		// two msgs in parallel, and another 110ms for the third)
+		// stop timeout of 90ms means we'll see the deadlock error
 		err = <-errc
-		assert.ErrorIs(t, err, flushErr)
+		assert.ErrorIs(t, err, errDeadlock)
+	})
+
+	t.Run("handle errors when errors returned from flush", func(t *testing.T) {
+
+		// This test deadlocks in failure
+		// Should figure out how to write it better
+
+		flushErr := errors.New("flush error")
+		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
+			time.Sleep(110 * time.Millisecond)
+			return flushErr
+		}
+		var errHandler = ErrorHandle[string](func(c context.Context, err error, msgs []kawa.Message[string]) error {
+			assert.ErrorIs(t, err, flushErr)
+			return err
+		})
+		bat := NewDestination[string](FlushFunc[string](ff), errHandler, FlushLength(2), FlushParallelism(2), StopTimeout(90*time.Millisecond))
+		errc := make(chan error)
+
+		ctx, cncl := context.WithCancel(context.Background())
+
+		go func(c context.Context, ec chan error) {
+			ec <- bat.Run(c)
+		}(ctx, errc)
+
+		writeMsgs := []kawa.Message[string]{
+			// will be blocked flushing
+			{Value: "hi"},
+			// will be stuck waiting for flush slot
+			{Value: "hello"},
+			// will be stuck waiting to write to msgs in Send
+			{Value: "bonjour"},
+		}
+
+		done := make(chan struct{})
+		err := bat.Send(ctx, func() { close(done) }, writeMsgs...)
+		assert.NoError(t, err, "errors aren't returned from Send")
+
+		cncl()
+
+		// parallelism is 2, so max processing time is 220ms (110ms for the first
+		// two msgs in parallel, and another 110ms for the third)
+		// stop timeout of 90ms means we'll see the deadlock error
+		err = <-errc
+		assert.ErrorIs(t, err, errDeadlock)
 	})
 
 	t.Run("dont deadlock on errors returned from flush with length 1", func(t *testing.T) {
@@ -247,7 +302,8 @@ func TestBatcherErrors(t *testing.T) {
 			time.Sleep(5 * time.Millisecond)
 			return flushErr
 		}
-		bat := NewDestination[string](FlushFunc[string](ff), FlushLength(1), FlushParallelism(2))
+		bat := NewDestination[string](FlushFunc[string](ff), Raise[string](), FlushLength(1), FlushParallelism(2),
+			StopTimeout(100*time.Millisecond))
 		errc := make(chan error)
 
 		ctx := context.Background()

--- a/x/batcher/batcher_test.go
+++ b/x/batcher/batcher_test.go
@@ -216,7 +216,13 @@ func TestBatcherErrors(t *testing.T) {
 			assert.ErrorIs(t, err, flushErr)
 			return err
 		})
-		bat := NewDestination[string](FlushFunc[string](ff), errHandler, FlushLength(2), FlushParallelism(2), StopTimeout(90*time.Millisecond))
+		bat := NewDestination[string](
+			FlushFunc[string](ff),
+			errHandler,
+			FlushLength(2),
+			FlushParallelism(2),
+			StopTimeout(90*time.Millisecond),
+		)
 		errc := make(chan error)
 
 		ctx, cncl := context.WithCancel(context.Background())
@@ -261,7 +267,13 @@ func TestBatcherErrors(t *testing.T) {
 			assert.ErrorIs(t, err, flushErr)
 			return err
 		})
-		bat := NewDestination[string](FlushFunc[string](ff), errHandler, FlushLength(2), FlushParallelism(2), StopTimeout(90*time.Millisecond))
+		bat := NewDestination[string](
+			FlushFunc[string](ff),
+			errHandler,
+			FlushLength(2),
+			FlushParallelism(2),
+			StopTimeout(90*time.Millisecond),
+		)
 		errc := make(chan error)
 
 		ctx, cncl := context.WithCancel(context.Background())

--- a/x/s3/s3.go
+++ b/x/s3/s3.go
@@ -84,6 +84,7 @@ func New(opts ...Option) *S3 {
 		ret.batchSize = 100
 	}
 	ret.batcher = batch.NewDestination[[]byte](ret,
+		batch.Raise[[]byte](),
 		batch.FlushLength(ret.batchSize),
 		batch.FlushFrequency(5*time.Second),
 	)


### PR DESCRIPTION
We previously were trying to handle errors either in Run() and previous to that: Send().  Unfortunately neither are great.

First when we tried send, the issue is that because batcher is async, the errors returned would have no semantic relation to the messages passed into the Send function call that just occurred.  It was _a_ way to pass errors back to the processor, but it leads to error handling which is error prone.

Next, we tried returning it from Run, but similarly the caller of `Run` has no context as to what it should do with the error.

Now, we're making error handling more explicit by requiring a handler get passed into the batcher.  The signature allows for fairly flexible error handling and includes the batch that failed to flush.

Returning an error from this new function will be an indicator to the batcher to stop processing and return the error to Run(), mimicking the current functionality, but with a lot more clarity and explicitness.

No error returned from the error handler means that the events were processed in a manner appropriate to the error, whether that be dropped, archived for later, or retried.

Be wary about retrying at this stage.  If you can rely on the source redelivering the message, better that than retrying here and putting backpressure on the queue.  Also better to archive or send to a deadletter queue for retries.