### PR TITLE
Add flush timeout & watchdog timer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         cache: true
 
     - name: Start containers
-      run: docker-compose -f "docker-compose.yml" up -d
+      run: docker compose -f "docker-compose.yml" up -d
 
     - name: Test
       run: make test
@@ -38,5 +38,5 @@ jobs:
       run: make lint
 
     - name: Stop containers
-      run: docker-compose -f "docker-compose.yml" down -v
+      run: docker compose -f "docker-compose.yml" down -v
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dist:
 
 .PHONY: compose
 compose:
-	docker-compose up -d
+	docker compose up -d
 
 .PHONY: lint
 lint: $(GOPATH)/bin/golangci-lint

--- a/x/batcher/batcher.go
+++ b/x/batcher/batcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -139,7 +140,7 @@ func NewDestination[T any](f Flusher[T], e ErrorHandler[T], opts ...OptFunc) *De
 		messages: make(chan msgAck[T]),
 	}
 
-	slog.Info(fmt.Sprintf("batcher init, dest: %p, msgs: %p", d, d.messages))
+	slog.Info(fmt.Sprintf("batcher init, dest: %p, msgs: %p", d, d.messages), "stack", string(debug.Stack()))
 
 	return d
 }

--- a/x/batcher/batcher.go
+++ b/x/batcher/batcher.go
@@ -13,6 +13,13 @@ import (
 	"github.com/segmentio/ksuid"
 )
 
+// Flusher is the core interface that the user of this package must implement
+// to get the batching functionality.
+// It takes a slice of messages and returns an error if the flush fails. It's
+// expected to be run synchronously and only return once the flush is complete.
+// The flusher MUST respond to the context being canceled and return an error
+// if the context is canceled.  If no other error occured, then return the
+// context error.
 type Flusher[T any] interface {
 	Flush(context.Context, []kawa.Message[T]) error
 }

--- a/x/batcher/batcher.go
+++ b/x/batcher/batcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -164,8 +163,6 @@ func NewDestination[T any](f Flusher[T], e ErrorHandler[T], opts ...OptFunc) *De
 		messages: make(chan msgAck[T]),
 	}
 
-	slog.Info(fmt.Sprintf("batcher init, dest: %p, msgs: %p", d, d.messages), "stack", string(debug.Stack()))
-
 	return d
 }
 
@@ -228,7 +225,6 @@ loop:
 	for {
 		select {
 		case <-wdChan:
-			slog.Info(fmt.Sprintf("batcher wd, dest: %p, msgs: %p", d, d.messages))
 			return errDeadlock
 
 		case msg := <-d.messages: // Here
@@ -293,7 +289,7 @@ loop:
 	return errDeadlock
 }
 
-var errDeadlock = errors.New("batcher: flushes timed out waiting for completion after context stopped.")
+var errDeadlock = errors.New("batcher: flushes timed out")
 
 func (d *Destination[T]) flush(ctx context.Context) {
 	// We make a new context here so that we can cancel the flush if the parent


### PR DESCRIPTION
We saw some flushes hanging writing to destinations using the batcher.

This PR adds a configuration option for both timeouts and a watchdog timer.

Setting the flush timer is recommended, and setting the watchdog timer is recommended as backup in case the flusher is not properly handling context cancellation. 