### PR TITLE
x/mqtt: add documentation

### DIFF
--- a/test/stream_test.go
+++ b/test/stream_test.go
@@ -55,7 +55,7 @@ func TestIO(t *testing.T) {
 }
 
 func TestMQTT(t *testing.T) {
-	mqttOpts := []mqtt.OptFunc{
+	mqttOpts := []mqtt.Option{
 		mqtt.WithBroker("mqtt://localhost:1883"),
 		mqtt.WithTopic("kawa/topic"),
 		mqtt.WithKeepAlive(5 * time.Second),


### PR DESCRIPTION
Fixed a couple bugs along the way:

- Incorrect order of Unsubscribe and Disconnect during Source shutdown.
- Acknowledge messages in `*Destination.Send`.

Unexport `Options` struct, because it's not usable by clients of the package.