### PR TITLE
single-message Send interface, context-like Attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.21"
+        go-version: "1.24"
         cache: true
 
     - name: Start containers

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint: $(GOPATH)/bin/golangci-lint
 	golangci-lint run --timeout 5m ./...
 
 $(GOPATH)/bin/golangci-lint:
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 
 $(GOPATH)/bin/golines:
 	$(GO) install github.com/segmentio/golines@latest

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ GOTAGS = testing
 
 GO ?= $(shell which go)
 
-export GOEXPERIMENT=nocoverageredesign
-
 .PHONY: test
 test: compose
 	$(GO) test -vet=off -tags='$(GOTAGS)' $(GOTESTFLAGS) -coverpkg="./..." -coverprofile=.coverprofile ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runreveal/kawa
 
-go 1.21
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go v1.44.313
@@ -11,7 +11,6 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/trace v1.19.0
-	golang.org/x/sys v0.21.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/processor.go
+++ b/processor.go
@@ -98,29 +98,16 @@ func (p *Processor[T1, T2]) handle(ctx context.Context) error {
 		recvSpan.End()
 
 		hctx, hdlSpan := tracer.Start(ctx, "kawa.processor.handler.handle")
-		msgs, err := p.handler.Handle(hctx, msg)
+		out, err := p.handler.Handle(hctx, msg)
 		if err != nil {
 			return fmt.Errorf("handler: %w", err)
 		}
 		hdlSpan.End()
 
-		// If there are no messages, we don't need to send nil to destination
-		if len(msgs) == 0 {
-			handleSpan.End()
-			Ack(ack)
-			continue
-		}
-
 		sctx, sendSpan := tracer.Start(ctx, "kawa.processor.dst.send")
-		for i, m := range msgs {
-			var msgAck func()
-			if i == len(msgs)-1 {
-				msgAck = ack
-			}
-			err = p.dst.Send(sctx, msgAck, m)
-			if err != nil {
-				return fmt.Errorf("destination: %w", err)
-			}
+		err = p.dst.Send(sctx, ack, out)
+		if err != nil {
+			return fmt.Errorf("destination: %w", err)
 		}
 		sendSpan.End()
 		handleSpan.End()

--- a/processor.go
+++ b/processor.go
@@ -112,9 +112,15 @@ func (p *Processor[T1, T2]) handle(ctx context.Context) error {
 		}
 
 		sctx, sendSpan := tracer.Start(ctx, "kawa.processor.dst.send")
-		err = p.dst.Send(sctx, ack, msgs...)
-		if err != nil {
-			return fmt.Errorf("destination: %w", err)
+		for i, m := range msgs {
+			var msgAck func()
+			if i == len(msgs)-1 {
+				msgAck = ack
+			}
+			err = p.dst.Send(sctx, msgAck, m)
+			if err != nil {
+				return fmt.Errorf("destination: %w", err)
+			}
 		}
 		sendSpan.End()
 		handleSpan.End()

--- a/processor_test.go
+++ b/processor_test.go
@@ -30,8 +30,8 @@ func TestProcessor(t *testing.T) {
 	}
 
 	countMessages := kawa.HandlerFunc[*BinString, *BinString](
-		func(c context.Context, m kawa.Message[*BinString]) ([]kawa.Message[*BinString], error) {
-			return []kawa.Message[*BinString]{m}, nil
+		func(c context.Context, m kawa.Message[*BinString]) (kawa.Message[*BinString], error) {
+			return m, nil
 		})
 
 	p, _ := kawa.New[*BinString, *BinString](kawa.Config[*BinString, *BinString]{

--- a/test/stream_test.go
+++ b/test/stream_test.go
@@ -49,7 +49,7 @@ func TestIO(t *testing.T) {
 		// close the writer to signal the end of the stream
 		// there's no easy way to do this implicitly without making
 		// readers/writers into closers.  Maybe that's worth it?
-		writer.Close()
+		_ = writer.Close()
 	})
 	SuiteTest(t, scansrc, printdst)
 }

--- a/types.go
+++ b/types.go
@@ -155,34 +155,27 @@ func (df DestinationFunc[T]) Send(ctx context.Context, ack func(), msg Message[T
 }
 
 // Handler defines a function which operates on a single event of type T1 and
-// returns a list of events of type T2.  T1 and T2 may be equivalent types.
-// Returning an empty slice and a nil error indicates that the message passed
-// in was processed successfully, no output was necessary, and therefore should
-// be acknowledged by the processor as having been processed successfully.
+// returns a single event of type T2.  T1 and T2 may be equivalent types.
 type Handler[T1, T2 any] interface {
-	Handle(context.Context, Message[T1]) ([]Message[T2], error)
+	Handle(context.Context, Message[T1]) (Message[T2], error)
 }
 
-type HandlerFunc[T1, T2 any] func(context.Context, Message[T1]) ([]Message[T2], error)
+type HandlerFunc[T1, T2 any] func(context.Context, Message[T1]) (Message[T2], error)
 
-func (hf HandlerFunc[T1, T2]) Handle(ctx context.Context, msg Message[T1]) ([]Message[T2], error) {
+func (hf HandlerFunc[T1, T2]) Handle(ctx context.Context, msg Message[T1]) (Message[T2], error) {
 	return hf(ctx, msg)
 }
 
+// Pipe returns a Handler which passes a message through without modification.
 func Pipe[T any]() Handler[T, T] {
 	return pipe[T]{}
 }
 
 type pipe[T any] struct{}
 
-func (p pipe[T]) Handle(ctx context.Context, msg Message[T]) ([]Message[T], error) {
-	return []Message[T]{msg}, nil
+func (p pipe[T]) Handle(ctx context.Context, msg Message[T]) (Message[T], error) {
+	return msg, nil
 }
-
-// // Pipe is a handler which simply passes a message through without modification.
-// func Pipe[T any](ctx context.Context, msg Message[T]) ([]Message[T], error) {
-// 	return []Message[T]{msg}, nil
-// }
 
 type DeserFunc[T any] func([]byte) (T, error)
 

--- a/types.go
+++ b/types.go
@@ -25,8 +25,43 @@ type Message[T any] struct {
 	Attributes Attributes
 }
 
-type Attributes interface {
-	Unwrap() Attributes
+// Attributes is an opaque key-value store inspired by context.Context, but
+// without deadlines, timeouts, or cancellation. It is used to pass metadata
+// from a source implementation through to a consumer.
+//
+// The provided key must be comparable and should not be of type string or any
+// other built-in type to avoid collisions between packages. Users of
+// WithValue should define their own types for keys.
+//
+// The zero value is a valid empty Attributes.
+type Attributes struct {
+	parent *valueAttr
+}
+
+type valueAttr struct {
+	Attributes
+	key, val any
+}
+
+// WithValue returns a new Attributes that carries the given key-value pair
+// in addition to any values already present in the parent.
+func WithValue(parent Attributes, key, val any) Attributes {
+	if key == nil {
+		panic("nil key")
+	}
+	return Attributes{parent: &valueAttr{parent, key, val}}
+}
+
+// Value returns the value associated with this Attributes for key, or nil if
+// no value is associated with key. Successive calls to Value with the same
+// key return the same result.
+func (a Attributes) Value(key any) any {
+	for va := a.parent; va != nil; va = va.parent {
+		if va.key == key {
+			return va.val
+		}
+	}
+	return nil
 }
 
 // Source defines the abstraction for which kawa consumes or receives messages
@@ -85,9 +120,9 @@ func Ack(ack func()) {
 // but anything which is message oriented could be made into a Destination
 // (e.g. a newline-delimited-JSON file could conceivably be a Destination).
 type Destination[T any] interface {
-	// Send sends the passed in messages to the Destination. Implementations
+	// Send sends the passed in message to the Destination. Implementations
 	// _must_ listen on <-ctx.Done() and return ctx.Err() if the context finishes
-	// while waiting to send messages.
+	// while waiting to send the message.
 	//
 	// *Send need not be blocking*.  In the case of a non-blocking call to send,
 	// it's expected that ack will be called _only after_ the message has been
@@ -110,13 +145,13 @@ type Destination[T any] interface {
 	// inside a processor's handler function, then the programmer must decide
 	// themselves how to properly acknowledge the event, and recognize that
 	// destinations will probably be acknowledging the message as well.
-	Send(context.Context, func(), ...Message[T]) error
+	Send(context.Context, func(), Message[T]) error
 }
 
-type DestinationFunc[T any] func(context.Context, func(), ...Message[T]) error
+type DestinationFunc[T any] func(context.Context, func(), Message[T]) error
 
-func (df DestinationFunc[T]) Send(ctx context.Context, ack func(), msgs ...Message[T]) error {
-	return df(ctx, ack, msgs...)
+func (df DestinationFunc[T]) Send(ctx context.Context, ack func(), msg Message[T]) error {
+	return df(ctx, ack, msg)
 }
 
 // Handler defines a function which operates on a single event of type T1 and

--- a/x/batcher/batcher.go
+++ b/x/batcher/batcher.go
@@ -251,27 +251,17 @@ type msgAck[T any] struct {
 	ack func()
 }
 
-// Send satisfies the kawa.Destination interface and accepts messages to be
+// Send satisfies the kawa.Destination interface and accepts a message to be
 // buffered for flushing after the FlushLength limit is reached or the
 // FlushFrequency timer fires, whichever comes first.
 //
-// Messages will not be acknowledged until they have been flushed successfully.
-func (d *Destination[T]) Send(ctx context.Context, ack func(), msgs ...kawa.Message[T]) error {
-	if len(msgs) < 1 {
-		return nil
+// The message will not be acknowledged until it has been flushed successfully.
+func (d *Destination[T]) Send(ctx context.Context, ack func(), msg kawa.Message[T]) error {
+	select {
+	case d.messages <- msgAck[T]{msg: msg, ack: ack}:
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-
-	callMe := ackFn(ack, len(msgs))
-
-	for _, m := range msgs {
-		select {
-		case d.messages <- msgAck[T]{msg: m, ack: callMe}: // Here
-		case <-ctx.Done():
-			// TODO: one more flush?
-			return ctx.Err()
-		}
-	}
-
 	return nil
 }
 
@@ -539,20 +529,3 @@ func (d *Destination[T]) doflush(ctx context.Context, msgs []kawa.Message[T], ac
 	d.flusherr <- handlerErr
 }
 
-// only call ack on last message acknowledgement
-func ackFn(ack func(), num int) func() {
-	ackChu := make(chan struct{}, num-1)
-	for i := 0; i < num-1; i++ {
-		ackChu <- struct{}{}
-	}
-	// bless you
-	return func() {
-		select {
-		case <-ackChu:
-		default:
-			if ack != nil {
-				ack()
-			}
-		}
-	}
-}

--- a/x/batcher/batcher.go
+++ b/x/batcher/batcher.go
@@ -528,4 +528,3 @@ func (d *Destination[T]) doflush(ctx context.Context, msgs []kawa.Message[T], ac
 	// Error handler returned an error - propagate it to stop the batcher
 	d.flusherr <- handlerErr
 }
-

--- a/x/batcher/batcher_test.go
+++ b/x/batcher/batcher_test.go
@@ -3,7 +3,6 @@ package batch
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,28 +11,6 @@ import (
 	"github.com/runreveal/kawa"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestAckChu(t *testing.T) {
-	var called bool
-	callMe := ackFn(func() { called = true }, 2)
-	for i := 0; i < 2; i++ {
-		callMe()
-	}
-	assert.True(t, called, "ack should be called")
-
-	nilMe := ackFn(nil, 2)
-	for i := 0; i < 2; i++ {
-		// shouldn't panic
-		nilMe()
-	}
-}
-
-// func flushTest[T any](c context.Context, msgs []kawa.Message[T]) {
-// 	for _, msg := range msgs {
-// 		fmt.Println(msg.Value)
-// 	}
-// 	counter++
-// }
 
 func TestBatcher(t *testing.T) {
 
@@ -61,8 +38,14 @@ func TestBatcher(t *testing.T) {
 	}
 
 	done := make(chan struct{})
-	err := bat.Send(ctx, func() { close(done) }, writeMsgs...)
-	assert.NoError(t, err)
+	for i, m := range writeMsgs {
+		var ack func()
+		if i == len(writeMsgs)-1 {
+			ack = func() { close(done) }
+		}
+		err := bat.Send(ctx, ack, m)
+		assert.NoError(t, err)
+	}
 
 	select {
 	case err := <-errc:
@@ -74,16 +57,13 @@ func TestBatcher(t *testing.T) {
 }
 
 func TestBatchFlushTimeout(t *testing.T) {
-	hMu := sync.Mutex{}
-	handled := false
+	handled := make(chan struct{})
 
 	var ff = func(c context.Context, msgs []kawa.Message[string]) error {
 		for _, msg := range msgs {
 			fmt.Println(msg.Value)
 		}
-		hMu.Lock()
-		handled = true
-		hMu.Unlock()
+		close(handled)
 		return nil
 	}
 
@@ -107,11 +87,11 @@ func TestBatchFlushTimeout(t *testing.T) {
 	err := bat.Send(ctx, func() { close(done) }, kawa.Message[string]{Value: "hi"})
 	assert.NoError(t, err)
 
-	time.Sleep(15 * time.Millisecond)
-
-	hMu.Lock()
-	assert.True(t, handled, "value should have been set!")
-	hMu.Unlock()
+	select {
+	case <-handled:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("flush not called in time")
+	}
 
 	select {
 	case err := <-errc:
@@ -137,12 +117,8 @@ func TestBatcherErrors(t *testing.T) {
 			ec <- bat.Run(c)
 		}(ctx, errc)
 
-		writeMsgs := []kawa.Message[string]{
-			{Value: "hi"},
-		}
-
 		done := make(chan struct{})
-		err := bat.Send(ctx, func() { close(done) }, writeMsgs...)
+		err := bat.Send(ctx, func() { close(done) }, kawa.Message[string]{Value: "hi"})
 		assert.NoError(t, err)
 
 		select {
@@ -195,19 +171,22 @@ func TestBatcherErrors(t *testing.T) {
 		}
 
 		done := make(chan struct{})
-		err := bat.Send(ctx, func() { close(done) }, writeMsgs...)
-		assert.NoError(t, err)
+		for i, m := range writeMsgs {
+			var ack func()
+			if i == len(writeMsgs)-1 {
+				ack = func() { close(done) }
+			}
+			err := bat.Send(ctx, ack, m)
+			assert.NoError(t, err)
+		}
 		cancel()
 
-		err = <-errc
+		err := <-errc
 		assert.ErrorIs(t, err, errDeadlock, "should return deadlock error")
 	})
 
 	t.Run("handle errors when errors returned from flush", func(t *testing.T) {
 
-		// This test deadlocks in failure
-		// Should figure out how to write it better
-
 		flushErr := errors.New("flush error")
 		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
 			time.Sleep(110 * time.Millisecond)
@@ -233,82 +212,28 @@ func TestBatcherErrors(t *testing.T) {
 		}(ctx, errc)
 
 		writeMsgs := []kawa.Message[string]{
-			// will be blocked flushing
 			{Value: "hi"},
-			// will be stuck waiting for flush slot
 			{Value: "hello"},
-			// will be stuck waiting to write to msgs in Send
 			{Value: "bonjour"},
 		}
 
 		done := make(chan struct{})
-		err := bat.Send(ctx, func() { close(done) }, writeMsgs...)
-		assert.NoError(t, err, "errors aren't returned from Send")
+		for i, m := range writeMsgs {
+			var ack func()
+			if i == len(writeMsgs)-1 {
+				ack = func() { close(done) }
+			}
+			err := bat.Send(ctx, ack, m)
+			assert.NoError(t, err, "errors aren't returned from Send")
+		}
 
 		cncl()
 
-		// parallelism is 2, so max processing time is 220ms (110ms for the first
-		// two msgs in parallel, and another 110ms for the third)
-		// stop timeout of 90ms means we'll see the deadlock error
-		err = <-errc
-		assert.ErrorIs(t, err, errDeadlock)
-	})
-
-	t.Run("handle errors when errors returned from flush", func(t *testing.T) {
-
-		// This test deadlocks in failure
-		// Should figure out how to write it better
-
-		flushErr := errors.New("flush error")
-		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
-			time.Sleep(110 * time.Millisecond)
-			return flushErr
-		}
-		var errHandler = ErrorFunc[string](func(c context.Context, err error, msgs []kawa.Message[string]) error {
-			assert.ErrorIs(t, err, flushErr)
-			return err
-		})
-		bat := NewDestination[string](
-			FlushFunc[string](ff),
-			errHandler,
-			FlushLength(2),
-			FlushParallelism(2),
-			StopTimeout(90*time.Millisecond),
-		)
-		errc := make(chan error)
-
-		ctx, cncl := context.WithCancel(context.Background())
-
-		go func(c context.Context, ec chan error) {
-			ec <- bat.Run(c)
-		}(ctx, errc)
-
-		writeMsgs := []kawa.Message[string]{
-			// will be blocked flushing
-			{Value: "hi"},
-			// will be stuck waiting for flush slot
-			{Value: "hello"},
-			// will be stuck waiting to write to msgs in Send
-			{Value: "bonjour"},
-		}
-
-		done := make(chan struct{})
-		err := bat.Send(ctx, func() { close(done) }, writeMsgs...)
-		assert.NoError(t, err, "errors aren't returned from Send")
-
-		cncl()
-
-		// parallelism is 2, so max processing time is 220ms (110ms for the first
-		// two msgs in parallel, and another 110ms for the third)
-		// stop timeout of 90ms means we'll see the deadlock error
-		err = <-errc
+		err := <-errc
 		assert.ErrorIs(t, err, errDeadlock)
 	})
 
 	t.Run("dont deadlock on errors returned from flush with length 1", func(t *testing.T) {
-
-		// This test deadlocks in failure
-		// Should figure out how to write it better
 
 		flushErr := errors.New("flush error")
 		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
@@ -326,19 +251,22 @@ func TestBatcherErrors(t *testing.T) {
 		}(ctx, errc)
 
 		writeMsgs := []kawa.Message[string]{
-			// will be blocked flushing
 			{Value: "hi"},
-			// will be stuck waiting for flush slot
 			{Value: "hello"},
-			// will be stuck waiting to write to msgs in Send
 			{Value: "bonjour"},
 		}
 
 		done := make(chan struct{})
-		err := bat.Send(ctx, func() { close(done) }, writeMsgs...)
-		assert.NoError(t, err)
+		for i, m := range writeMsgs {
+			var ack func()
+			if i == len(writeMsgs)-1 {
+				ack = func() { close(done) }
+			}
+			err := bat.Send(ctx, ack, m)
+			assert.NoError(t, err)
+		}
 
-		err = <-errc
+		err := <-errc
 		assert.ErrorIs(t, err, flushErr)
 	})
 
@@ -368,12 +296,18 @@ func TestBatcherErrors(t *testing.T) {
 		}
 
 		ackCount := 0
-		err := bat.Send(ctx, func() { ackCount += 1 }, messages...)
-		assert.NoError(t, err)
+		for i, m := range messages {
+			var ack func()
+			if i == len(messages)-1 {
+				ack = func() { ackCount++ }
+			}
+			err := bat.Send(ctx, ack, m)
+			assert.NoError(t, err)
+		}
 		time.Sleep(50 * time.Millisecond)
 		cancel()
 
-		err = <-errc
+		err := <-errc
 		assert.ErrorIs(t, err, nil)
 
 		assert.Equal(t, 0, ackCount)
@@ -392,7 +326,6 @@ func TestBatcherRetry(t *testing.T) {
 		}
 
 		var errHandler = ErrorFunc[string](func(c context.Context, err error, msgs []kawa.Message[string]) error {
-			// Just pass through the error
 			return err
 		})
 
@@ -419,10 +352,8 @@ func TestBatcherRetry(t *testing.T) {
 		err := bat.Send(ctx, func() { close(ackChan) }, kawa.Message[string]{Value: "hi"})
 		assert.NoError(t, err)
 
-		// Wait for ack to happen
 		select {
 		case <-ackChan:
-			// Success - message was acked
 		case <-time.After(200 * time.Millisecond):
 			t.Fatal("timeout waiting for ack")
 		}
@@ -483,7 +414,6 @@ func TestBatcherRetry(t *testing.T) {
 		}
 
 		var errHandler = ErrorFunc[string](func(c context.Context, err error, msgs []kawa.Message[string]) error {
-			// Just pass through the error
 			return err
 		})
 
@@ -567,7 +497,6 @@ func TestBatcherRetry(t *testing.T) {
 		}
 
 		var errHandler = ErrorFunc[string](func(c context.Context, err error, msgs []kawa.Message[string]) error {
-			// Return ErrDontAck, should not retry
 			return ErrDontAck
 		})
 
@@ -603,7 +532,6 @@ func TestBatcherRetry(t *testing.T) {
 		var attemptCount atomic.Int32
 		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
 			attemptCount.Add(1)
-			// Sleep longer than timeout to trigger deadline exceeded
 			time.Sleep(100 * time.Millisecond)
 			return c.Err()
 		}
@@ -616,7 +544,7 @@ func TestBatcherRetry(t *testing.T) {
 			FlushFunc[string](ff),
 			errHandler,
 			FlushLength(1),
-			FlushTimeout(50*time.Millisecond), // Timeout shorter than flush operation
+			FlushTimeout(50*time.Millisecond),
 			MaxRetries(2),
 			InitialBackoff(10*time.Millisecond),
 			IsRetryable(func(err error) bool {
@@ -637,7 +565,6 @@ func TestBatcherRetry(t *testing.T) {
 
 		err = <-errc
 		assert.ErrorIs(t, err, context.DeadlineExceeded)
-		// Should have tried 3 times, each time getting timeout
 		assert.Equal(t, int32(3), attemptCount.Load(), "should have made 3 attempts")
 	})
 
@@ -657,7 +584,7 @@ func TestBatcherRetry(t *testing.T) {
 			FlushFunc[string](ff),
 			errHandler,
 			FlushLength(1),
-			MaxRetries(0), // No retries
+			MaxRetries(0),
 			IsRetryable(func(err error) bool {
 				return err != nil
 			}),
@@ -704,15 +631,11 @@ func TestWatchdog(t *testing.T) {
 			ec <- bat.Run(c)
 		}(ctx, errc)
 
-		// Send one message, which will flush after 50ms
 		err := bat.Send(ctx, nil, kawa.Message[string]{Value: "message1"})
 		assert.NoError(t, err)
 
-		// Wait for flush to happen
 		time.Sleep(70 * time.Millisecond)
 
-		// Now system is idle. Watchdog is 100ms, but no flushes are in-flight
-		// so it should reset and not error
 		time.Sleep(150 * time.Millisecond)
 
 		cancel()
@@ -723,7 +646,6 @@ func TestWatchdog(t *testing.T) {
 
 	t.Run("stuck flush with no new messages triggers watchdog", func(t *testing.T) {
 		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
-			// Simulate a flush that ignores context cancellation
 			time.Sleep(1 * time.Second)
 			return nil
 		}
@@ -732,7 +654,7 @@ func TestWatchdog(t *testing.T) {
 			FlushFunc[string](ff),
 			Raise[string](),
 			FlushLength(1),
-			FlushTimeout(50*time.Millisecond), // Context will be cancelled, but flush ignores it
+			FlushTimeout(50*time.Millisecond),
 			WatchdogTimeout(150*time.Millisecond),
 		)
 
@@ -744,11 +666,9 @@ func TestWatchdog(t *testing.T) {
 			ec <- bat.Run(c)
 		}(ctx, errc)
 
-		// Send one message which will trigger a flush
 		err := bat.Send(ctx, nil, kawa.Message[string]{Value: "message1"})
 		assert.NoError(t, err)
 
-		// Watchdog should fire after 150ms because flush is stuck
 		err = <-errc
 		assert.ErrorIs(t, err, errDeadlock, "stuck flush should trigger watchdog")
 	})
@@ -758,11 +678,9 @@ func TestWatchdog(t *testing.T) {
 		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
 			count := flushCount.Add(1)
 			if count == 1 {
-				// First flush gets stuck and ignores context
 				time.Sleep(1 * time.Second)
 				return nil
 			}
-			// Subsequent flushes complete quickly
 			return nil
 		}
 
@@ -770,7 +688,7 @@ func TestWatchdog(t *testing.T) {
 			FlushFunc[string](ff),
 			Raise[string](),
 			FlushLength(1),
-			FlushParallelism(2), // Allow parallel flushes
+			FlushParallelism(2),
 			FlushTimeout(50*time.Millisecond),
 			WatchdogTimeout(200*time.Millisecond),
 		)
@@ -783,22 +701,17 @@ func TestWatchdog(t *testing.T) {
 			ec <- bat.Run(c)
 		}(ctx, errc)
 
-		// Send first message - this will get stuck
 		err := bat.Send(ctx, nil, kawa.Message[string]{Value: "message1"})
 		assert.NoError(t, err)
 
-		// Wait a bit for first flush to start
 		time.Sleep(30 * time.Millisecond)
 
-		// Send more messages periodically to keep resetting the old watchdog
-		// With our new implementation, this should still detect the stuck flush
 		for i := 0; i < 3; i++ {
 			time.Sleep(80 * time.Millisecond)
 			err := bat.Send(ctx, nil, kawa.Message[string]{Value: fmt.Sprintf("message%d", i+2)})
 			assert.NoError(t, err)
 		}
 
-		// Watchdog should eventually fire because first flush is stuck
 		err = <-errc
 		assert.ErrorIs(t, err, errDeadlock, "stuck flush should trigger watchdog even with new messages")
 	})
@@ -807,7 +720,6 @@ func TestWatchdog(t *testing.T) {
 		var flushCount atomic.Int32
 		var ff = func(c context.Context, msgs []kawa.Message[string]) error {
 			flushCount.Add(1)
-			// Each flush takes 80ms, but completes successfully
 			time.Sleep(80 * time.Millisecond)
 			return nil
 		}
@@ -827,13 +739,11 @@ func TestWatchdog(t *testing.T) {
 			ec <- bat.Run(c)
 		}(ctx, errc)
 
-		// Send 3 messages, each will flush independently
 		for i := 0; i < 3; i++ {
 			err := bat.Send(ctx, nil, kawa.Message[string]{Value: fmt.Sprintf("message%d", i+1)})
 			assert.NoError(t, err)
 		}
 
-		// Wait for all flushes to complete
 		time.Sleep(300 * time.Millisecond)
 
 		cancel()

--- a/x/memory/memory.go
+++ b/x/memory/memory.go
@@ -42,18 +42,16 @@ func NewMemDestination[T any](out chan<- T) MemoryDestination[T] {
 	}
 }
 
-// Send implements [kawa.Destination] by sending the messages sequentially on the channel.
-// If ctx.Done() is closed before all the messages are sent.
+// Send implements [kawa.Destination] by sending the message on the channel.
+// If ctx.Done() is closed before the message is sent,
 // then Send returns ctx.Err().
-// If ack is not nil, then it will be called after all the messages are sent
+// If ack is not nil, then it will be called after the message is sent
 // but before Send returns.
-func (ms MemoryDestination[T]) Send(ctx context.Context, ack func(), msgs ...kawa.Message[T]) error {
-	for _, msg := range msgs {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case ms.MsgC <- msg.Value:
-		}
+func (ms MemoryDestination[T]) Send(ctx context.Context, ack func(), msg kawa.Message[T]) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case ms.MsgC <- msg.Value:
 	}
 	kawa.Ack(ack)
 	return nil

--- a/x/mqtt/mqtt.go
+++ b/x/mqtt/mqtt.go
@@ -184,14 +184,12 @@ func (dest *Destination) Run(ctx context.Context) error {
 	return err
 }
 
-// Send publishes each message in the batch to the configured topic.
-func (dest *Destination) Send(ctx context.Context, ack func(), msgs ...kawa.Message[[]byte]) error {
-	for _, msg := range msgs {
-		token := dest.client.Publish(dest.cfg.topic, dest.cfg.qos, dest.cfg.retained, string(msg.Value))
-		token.Wait()
-		if token.Error() != nil {
-			return token.Error()
-		}
+// Send publishes the message to the configured topic.
+func (dest *Destination) Send(ctx context.Context, ack func(), msg kawa.Message[[]byte]) error {
+	token := dest.client.Publish(dest.cfg.topic, dest.cfg.qos, dest.cfg.retained, string(msg.Value))
+	token.Wait()
+	if token.Error() != nil {
+		return token.Error()
 	}
 	kawa.Ack(ack)
 	return nil

--- a/x/multi/multidest.go
+++ b/x/multi/multidest.go
@@ -17,12 +17,12 @@ func NewMultiDestination[T any](dests []kawa.Destination[T]) MultiDestination[T]
 	}
 }
 
-func (md MultiDestination[T]) Send(ctx context.Context, ack func(), msgs ...kawa.Message[T]) error {
+func (md MultiDestination[T]) Send(ctx context.Context, ack func(), msg kawa.Message[T]) error {
 	if ack != nil {
 		ack = ackFn(ack, len(md.wrapped))
 	}
 	for _, d := range md.wrapped {
-		err := d.Send(ctx, ack, msgs...)
+		err := d.Send(ctx, ack, msg)
 		if err != nil {
 			return err
 		}
@@ -30,13 +30,12 @@ func (md MultiDestination[T]) Send(ctx context.Context, ack func(), msgs ...kawa
 	return nil
 }
 
-// only call ack on last message acknowledgement
+// only call ack on last destination acknowledgement
 func ackFn(ack func(), num int) func() {
 	ackChu := make(chan struct{}, num-1)
 	for i := 0; i < num-1; i++ {
 		ackChu <- struct{}{}
 	}
-	// bless you
 	return func() {
 		select {
 		case <-ackChu:

--- a/x/printer/printer.go
+++ b/x/printer/printer.go
@@ -43,13 +43,9 @@ func NewPrinter(writer io.Writer, opts ...Option) *Printer {
 	return ret
 }
 
-// Send implements [kawa.Destination] by writing each message value followed by the printer's delimiter.
-// A call to Send will call Write at most once on the underlying writer.
-func (p *Printer) Send(ctx context.Context, ack func(), msg ...kawa.Message[[]byte]) error {
-	n := len(p.delim) * len(msg)
-	for _, m := range msg {
-		n += len(m.Value)
-	}
+// Send implements [kawa.Destination] by writing the message value followed by the printer's delimiter.
+func (p *Printer) Send(ctx context.Context, ack func(), msg kawa.Message[[]byte]) error {
+	n := len(msg.Value) + len(p.delim)
 
 	select {
 	case p.mu <- struct{}{}:
@@ -57,10 +53,8 @@ func (p *Printer) Send(ctx context.Context, ack func(), msg ...kawa.Message[[]by
 		return ctx.Err()
 	}
 	p.buf = slices.Grow(p.buf[:0], n)
-	for _, m := range msg {
-		p.buf = append(p.buf, m.Value...)
-		p.buf = append(p.buf, p.delim...)
-	}
+	p.buf = append(p.buf, msg.Value...)
+	p.buf = append(p.buf, p.delim...)
 	_, err := p.writer.Write(p.buf)
 	<-p.mu // Release mutex as soon as possible after Write.
 

--- a/x/printer/printer_test.go
+++ b/x/printer/printer_test.go
@@ -64,19 +64,24 @@ func TestPrinter(t *testing.T) {
 			p := NewPrinter(buf, options...)
 
 			for i, batch := range test.sends {
-				batchMessages := make([]kawa.Message[[]byte], len(batch))
-				for i, s := range batch {
-					batchMessages[i] = kawa.Message[[]byte]{
-						Value: []byte(s),
+				for j, s := range batch {
+					var ack func()
+					if j == len(batch)-1 {
+						callCount := 0
+						ack = func() { callCount++ }
+						err := p.Send(ctx, ack, kawa.Message[[]byte]{Value: []byte(s)})
+						if err != nil {
+							t.Errorf("Error sending message #%d in batch #%d: %v", j+1, i+1, err)
+						}
+						if callCount != 1 {
+							t.Errorf("ack function called %d times for last message in batch #%d; want 1", callCount, i+1)
+						}
+					} else {
+						err := p.Send(ctx, nil, kawa.Message[[]byte]{Value: []byte(s)})
+						if err != nil {
+							t.Errorf("Error sending message #%d in batch #%d: %v", j+1, i+1, err)
+						}
 					}
-				}
-				callCount := 0
-				err := p.Send(ctx, func() { callCount++ }, batchMessages...)
-				if err != nil {
-					t.Errorf("Error sending batch #%d: %v", i+1, err)
-				}
-				if callCount != 1 {
-					t.Errorf("ack function called %d times during batch #%d; want 1", callCount, i+1)
 				}
 			}
 

--- a/x/s3/s3.go
+++ b/x/s3/s3.go
@@ -99,8 +99,8 @@ func (s *S3) Run(ctx context.Context) error {
 	return s.batcher.Run(ctx)
 }
 
-func (s *S3) Send(ctx context.Context, ack func(), msgs ...kawa.Message[[]byte]) error {
-	return s.batcher.Send(ctx, ack, msgs...)
+func (s *S3) Send(ctx context.Context, ack func(), msg kawa.Message[[]byte]) error {
+	return s.batcher.Send(ctx, ack, msg)
 }
 
 // Flush sends the given messages of type kawa.Message[type.Event] to an s3 bucket


### PR DESCRIPTION
Change `Destination.Send` from variadic `...Message[T]` to single `Message[T]`, simplifying the interface contract and pushing batching concerns to the batcher.

Replace the `Attributes interface (Unwrap() Attributes)` with a concrete struct mirroring context.Context's value chain: `WithValue(parent, key, val)` and `Value(key)` — no deadlines, timeouts, or cancellation.