### PR TITLE
batcher: Unblock Send() callers if Run() has exited

### DIFF
--- a/x/batcher/batcher.go
+++ b/x/batcher/batcher.go
@@ -76,6 +76,7 @@ type Destination[T any] struct {
 
 	messages chan msgAck[T]
 	buf      []msgAck[T]
+	done     chan struct{}
 
 	count   int
 	running bool
@@ -241,6 +242,7 @@ func NewDestination[T any](f Flusher[T], e ErrorHandler[T], opts ...OptFunc) *De
 		isRetryable:       cfg.IsRetryable,
 
 		messages: make(chan msgAck[T]),
+		done:     make(chan struct{}),
 	}
 
 	return d
@@ -251,6 +253,8 @@ type msgAck[T any] struct {
 	ack func()
 }
 
+var ErrNotRunning = errors.New("batcher: not running")
+
 // Send satisfies the kawa.Destination interface and accepts a message to be
 // buffered for flushing after the FlushLength limit is reached or the
 // FlushFrequency timer fires, whichever comes first.
@@ -259,6 +263,8 @@ type msgAck[T any] struct {
 func (d *Destination[T]) Send(ctx context.Context, ack func(), msg kawa.Message[T]) error {
 	select {
 	case d.messages <- msgAck[T]{msg: msg, ack: ack}:
+	case <-d.done:
+		return ErrNotRunning
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -271,6 +277,8 @@ func (d *Destination[T]) Send(ctx context.Context, ack func(), msg kawa.Message[
 // Upon cancellation, Run will flush any remaining messages in the buffer and
 // return any flush errors that occur
 func (d *Destination[T]) Run(ctx context.Context) error {
+	defer close(d.done)
+
 	var epoch uint64
 	epochC := make(chan uint64)
 	setTimer := true
@@ -334,7 +342,10 @@ loop:
 				// copy the epoch to send on the chan after the timer fires
 				epc := epoch
 				time.AfterFunc(d.flushfreq, func() {
-					epochC <- epc // Here
+					select {
+					case epochC <- epc:
+					case <-d.done:
+					}
 				})
 
 				if wdTimer != nil {

--- a/x/batcher/batcher_test.go
+++ b/x/batcher/batcher_test.go
@@ -752,3 +752,90 @@ func TestWatchdog(t *testing.T) {
 		assert.Equal(t, int32(3), flushCount.Load(), "should have completed 3 flushes")
 	})
 }
+
+func TestSendReturnsAfterRunExits(t *testing.T) {
+	// When Run's context is canceled but the caller's Send context is still
+	// alive, Send should return ErrNotRunning instead of blocking forever.
+
+	slowFlush := func(ctx context.Context, msgs []kawa.Message[string]) error {
+		select {
+		case <-time.After(5 * time.Second):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		return nil
+	}
+
+	bat := NewDestination[string](
+		FlushFunc[string](slowFlush),
+		Raise[string](),
+		FlushLength(100),
+		FlushFrequency(10*time.Second),
+	)
+
+	runCtx, runCancel := context.WithCancel(context.Background())
+
+	// Use a separate context for Send to simulate callers whose lifecycle
+	// outlives the batcher (e.g. a long-lived processor goroutine).
+	sendCtx, sendCancel := context.WithCancel(context.Background())
+	defer sendCancel()
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- bat.Run(runCtx)
+	}()
+
+	err := bat.Send(sendCtx, nil, kawa.Message[string]{Value: "msg1"})
+	assert.NoError(t, err)
+
+	runCancel()
+	<-runErr
+
+	// Now Send should return ErrNotRunning promptly, not block forever
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- bat.Send(sendCtx, nil, kawa.Message[string]{Value: "msg2"})
+	}()
+
+	select {
+	case err := <-sendDone:
+		assert.ErrorIs(t, err, ErrNotRunning)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send blocked after Run exited — done channel fix not working")
+	}
+}
+
+func TestTimerGoroutineCleanup(t *testing.T) {
+	// Verify that timer goroutines don't leak when Run exits before the
+	// flush timer fires.
+
+	bat := NewDestination[string](
+		FlushFunc[string](func(_ context.Context, msgs []kawa.Message[string]) error {
+			return nil
+		}),
+		Raise[string](),
+		FlushLength(1000),
+		FlushFrequency(50*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- bat.Run(ctx)
+	}()
+
+	err := bat.Send(ctx, nil, kawa.Message[string]{Value: "trigger"})
+	assert.NoError(t, err)
+
+	// Cancel before the flush timer fires
+	cancel()
+	<-runErr
+
+	// Wait for any pending timer callbacks to fire and resolve
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify Send returns immediately instead of blocking on a dead batcher.
+	sendErr := bat.Send(context.Background(), nil, kawa.Message[string]{Value: "after"})
+	assert.ErrorIs(t, sendErr, ErrNotRunning)
+}


### PR DESCRIPTION
Summary

When a batcher's Run() context is canceled, goroutines blocked in Send() hang forever, permanently stalling the process.

Problem

Send() blocks on two channels: d.messages (to deliver the message to Run()) and ctx.Done() (the caller's context). When Run() exits — due to its own context being canceled, a watchdog timeout, or a flush error — nobody reads from d.messages anymore. If the caller's context is still alive (which is typical when the caller's lifecycle
is scoped to the process rather than the destination), Send() blocks indefinitely.

This means any system that tears down and recreates batchers during the process lifetime (e.g., in response to config changes) will accumulate permanently stuck goroutines. The blocked Send() callers never return, so the retry/re-initialization path never triggers, and the process silently stops making progress.

A secondary leak exists in the time.AfterFunc flush timer callback, which does a blocking send on epochC. After Run() exits, these timer goroutines also block forever.

Fix

Add a done channel to Destination that is closed when Run() exits. Send() selects on this channel and returns ErrNotRunning immediately, allowing callers to unblock and retry. The timer callback uses the same channel to bail out instead of blocking.